### PR TITLE
Feat: Accept Builder argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Builder::hasByNonDependentSubquery(
 | Feature | [`mpyw/eloquent-has-by-join`](https://github.com/mpyw/eloquent-has-by-join) | `mpyw/eloquent-has-by-non-dependent-subquery` |
 |:----|:---:|:---:|
 | Minimum Laravel version | 5.6 | 5.8 |
-| Argument of optional constraints | `Illuminate\Database\Eloquent\Builder` | `Illuminate\Database\Eloquent\Relations\*` |
+| Argument of optional constraints | `Illuminate\Database\Eloquent\Builder` | `Illuminate\Database\Eloquent\Relations\*`<br>(`Builder` can be also accepted by specifying argument type) |
 | [Compoships](https://github.com/topclaudy/compoships) support | ✅ | ❌ |
 | No subqueries | ✅ | ❌<br>(Performance depends on database optimizers) |
 | No table collisions | ❌<br>(Sometimes you need to give aliases) | ✅ |

--- a/src/ReflectionCallable.php
+++ b/src/ReflectionCallable.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Mpyw\EloquentHasByNonDependentSubquery;
+
+use Closure;
+use ReflectionFunction;
+use ReflectionMethod;
+
+/**
+ * Class ReflectionCallable
+ */
+class ReflectionCallable
+{
+    /** @noinspection PhpDocMissingThrowsInspection */
+
+    /**
+     * @param  callable                              $callable
+     * @return \ReflectionFunction|\ReflectionMethod
+     */
+    public static function from(callable $callable)
+    {
+        if (\is_string($callable) && \strpos($callable, '::')) {
+            $callable = \explode('::', $callable);
+        } elseif (!$callable instanceof Closure && \is_object($callable)) {
+            $callable = [$callable, '__invoke'];
+        }
+
+        /* @noinspection PhpUnhandledExceptionInspection */
+        return $callable instanceof Closure || \is_string($callable)
+            ? new ReflectionFunction($callable)
+            : new ReflectionMethod($callable[0], $callable[1]);
+    }
+}


### PR DESCRIPTION
We now accept a `Builder` argument to prevent common mistakes.

```php
Comment::query()->hasByNonDependentSubquery(
    'post',
    function (Relation $query) {
        // $query is a Relation instance
        $query->onlyTrashed();
    }
)->withTrashed()
```

```php
Comment::query()->hasByNonDependentSubquery(
    'post',
    function ($query) {
        // $query is a Relation instance
        $query->onlyTrashed();
    }
)->withTrashed()
```

```php
Comment::query()->hasByNonDependentSubquery(
    'post',
    function (Builder $query) {
        // $query is a Builder instance! (Previously it triggered an error)
        $query->onlyTrashed();
    }
)->withTrashed()
```