### PR TITLE
Add both qualified keys to WHERE clause

### DIFF
--- a/src/HasByNonDependentSubqueryMacro.php
+++ b/src/HasByNonDependentSubqueryMacro.php
@@ -131,6 +131,10 @@ class HasByNonDependentSubqueryMacro
         if ($keys->needsPolymorphicRelatedConstraints()) {
             $relation->where($keys->getQualifiedRelatedMorphType(), $keys->getRelatedMorphClass());
         }
+        
+        // Add both qualified keys to WHERE clause
+        $relation->whereColumn($keys->getQualifiedRelatedKeyName(), $keys->getQualifiedSourceKeyName());
+        
         $this->query->{$whereInMethod}($keys->getQualifiedSourceKeyName(), $relation->getQuery());
     }
 


### PR DESCRIPTION
Avoid engine to use _ALL_ query type by increasing the filtering.
## Old version
```sql
select * from `posts`
where `posts`.`id` in (
  select `comments`.`post_id` from `comments`
  where `comments`.`deleted_at` is null
)
and `posts`.`deleted_at` is null
```
| **id** | **select_type** |  **table**  | **type** | **possible_keys**         | **key**      | **key_ken** | **ref** | **rows** | **filtered** | **extra**                |
|:------:|:---------------:|:-----------:|----------|---------------------------|--------------|-------------|---------|----------|--------------|--------------------------|
| 1      | PRIMARY         | posts       | ref      | PRIMARY,posts_pk_2        | posts_pk_2   | 6           | const   | 1        | 100          | Using where; Using index |
| 1      | PRIMARY         | subquery2 | eq_ref   | distinct_key              | distinct_key | 4           | func    | 1        | 100          |                          |
| 2      | MATERIALIZED    | comments    | index      | comments_post_id_deleted_at_index | comments_post_id_deleted_at_index | 10 |         | 1        | 100          | Using where; Using index |



## Using qualified keys on filter
```sql
select * from `posts`
where `posts`.`id` in (
  select `comments`.`post_id` from `comments`
  where `comments`.`post_id` = `posts`.`id` and `comments`.`deleted_at` is null
)
and `posts`.`deleted_at` is null
```
| **id** | **select_type** | **table** | **type** | **possible_keys**         | **key**    | **key_ken** | **ref** | **rows** | **filtered** | **extra**                                                          |
|:------:|:---------------:|:---------:|----------|---------------------------|------------|-------------|---------|----------|--------------|--------------------------------------------------------------------|
| 1      | PRIMARY         | posts     | ref      | PRIMARY,posts_pk_2        | posts_pk_2 | 6           | const   | 1        | 100          | Using where; Using index                                           |
| 1      | PRIMARY         | comments  | ref      | comments_post_id_deleted_at_index | comments_post_id_deleted_at_index | 10 | test.posts.id,const | 1        | 100          | Using where; Using index; FirstMatch(posts) |
